### PR TITLE
User profile page and edit link work

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -16,11 +16,22 @@ class UsersController < ApplicationController
   end
 
   def show
+    @user = current_user
   end
 
+  def edit
+    @user = current_user
+  end
 
-private
-  #Need to make sure that user_params doesn't store password
+  def update
+    @user = current_user
+    @user.update(user_params)
+    redirect_to '/profile'
+    flash[:success] = 'Your profile has been updated'
+  end
+
+  private
+
   def user_params
     params.permit(:name, :address, :city, :state, :zip, :email, :password)
   end

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -1,0 +1,15 @@
+<%= form_tag '/profile', method: :patch do %>
+  <%= label_tag :name %>
+  <%= text_field_tag :name, "#{@user.name}"%>
+  <%= label_tag :address %>
+  <%= text_field_tag :address, "#{@user.address}"%>
+  <%= label_tag :city %>
+  <%= text_field_tag :city, "#{@user.city}"%>
+  <%= label_tag :state %>
+  <%= text_field_tag :state, "#{@user.state}"%>
+  <%= label_tag :zip %>
+  <%= text_field_tag :zip, "#{@user.zip}"%>
+  <%= label_tag :email %>
+  <%= text_field_tag :email, "#{@user.email}"%>
+  <%= submit_tag 'Update Profile' %>
+<% end %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,0 +1,7 @@
+<%= @user.name %>
+<%= @user.address %>
+<%= @user.city %>
+<%= @user.state %>
+<%= @user.zip %>
+<%= @user.email %>
+<%= link_to 'Edit Profile', '/profile/edit' %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -40,6 +40,8 @@ Rails.application.routes.draw do
   post "/users", to: "users#create"
 
   get "/profile", to: "users#show"
+  get '/profile/edit', to: 'users#edit'
+  patch '/profile', to: 'users#update'
 
   #I think login action is like a new action, could also call it new
   get "/login", to: "sessions#new"

--- a/spec/features/users/profile_spec.rb
+++ b/spec/features/users/profile_spec.rb
@@ -1,0 +1,63 @@
+require 'rails_helper'
+
+RSpec.describe "User Profile" do
+  describe "As a registered user" do
+    before :each do
+      @user = User.create(name: 'Christopher', address: '123 Oak Ave', city: 'Denver', state: 'CO', zip: 80021, email: 'christopher@email.com', password: 'p@ssw0rd', role: 0)
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@user)
+    end
+
+    it 'I visit my profile page and see all my profile data except my password. I see a link to edit my profile data.' do
+      visit '/profile'
+
+      expect(page).to have_content(@user.name)
+      expect(page).to have_content(@user.address)
+      expect(page).to have_content(@user.city)
+      expect(page).to have_content(@user.state)
+      expect(page).to have_content(@user.zip)
+      expect(page).to have_content(@user.email)
+      expect(page).to_not have_content(@user.password)
+      expect(page).to have_link('Edit Profile')
+    end
+
+    it 'I click the Edit Profile link. I see a prepopulate form with my current info. I submit the form and am returned to my profile page with my new info.' do
+      visit '/profile'
+      click_link 'Edit Profile'
+
+      expect(current_path).to eq('/profile/edit')
+
+      expect(find_field(:name).value).to eq(@user.name)
+      expect(find_field(:address).value).to eq(@user.address)
+      expect(find_field(:city).value).to eq(@user.city)
+      expect(find_field(:state).value).to eq(@user.state)
+      expect(find_field(:zip).value).to eq(@user.zip.to_s)
+      expect(find_field(:email).value).to eq(@user.email)
+
+
+      name = 'Christopher'
+      address = '456 1st St'
+      city = 'Northglenn'
+      state = 'CO'
+      zip = 80233
+      email = 'christopher@email.com'
+
+      fill_in "Name", with: name
+      fill_in "Email", with: email
+      fill_in "Address", with: address
+      fill_in "City", with: city
+      fill_in "State", with: state
+      fill_in "Zip", with: zip
+      click_button 'Update Profile'
+
+      expect(current_path).to eq('/profile')
+
+      expect(page).to have_content('Your profile has been updated')
+      expect(page).to have_content(name)
+      expect(page).to have_content(address)
+      expect(page).to have_content(city)
+      expect(page).to have_content(state)
+      expect(page).to have_content(zip)
+      expect(page).to have_content(email)
+    end
+  end
+end


### PR DESCRIPTION
User stories 18 and 19 are finished. Users have a profile page with a link to edit their profile. Their edited information shows up on their profile page and replaces the old information. 

Co-authored-by: Alec Wells <23268508+alect47@users.noreply.github.com>
Co-authored-by: Joshua Sherwood <49769068+joshsherwood1@users.noreply.github.com>