### PR TITLE
Add visitor checkout restrictions

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -24,7 +24,7 @@ class UsersController < ApplicationController
   def show
     @user = current_user
   end
-  
+
   def edit
     @user = current_user
   end
@@ -48,7 +48,7 @@ class UsersController < ApplicationController
     end
   end
 
-  
+
   private
 
   def require_user

--- a/app/views/cart/show.html.erb
+++ b/app/views/cart/show.html.erb
@@ -49,7 +49,9 @@
   <% if current_user %>
     <p><%= link_to "Checkout", "/orders/new", method: :get %></p>
   <% else %>
-    <h4>You must login or register in order to checkout</h4>
+  <section id='visitor-checkout-message'>
+    <h4>You must <%= link_to "log in", '/login' %> or <%= link_to "register", '/register' %> in order to checkout</h4>
+  </section>
   <% end %>
 <% else %>
   <h3 align= "center">Cart is currently empty</h3>

--- a/app/views/cart/show.html.erb
+++ b/app/views/cart/show.html.erb
@@ -46,7 +46,11 @@
 </table>
   <p>Total: <%= number_to_currency(cart.total) %></p>
   <p><%= link_to "Empty Cart", "/cart", method: :delete %></p>
-  <p><%= link_to "Checkout", "/orders/new", method: :get %></p>
+  <% if current_user %>
+    <p><%= link_to "Checkout", "/orders/new", method: :get %></p>
+  <% else %>
+    <h4>You must login or register in order to checkout</h4>
+  <% end %>
 <% else %>
   <h3 align= "center">Cart is currently empty</h3>
 <% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -31,7 +31,7 @@
       <section>
         <% if current_user %>
           <%= link_to "Logout", "/logout", method: :delete %>
-          <%= link_to "Profile" %>
+          <%= link_to "Profile", "/profile" %>
           <p>Logged in as <%= current_user.name %></p>
           <% if current_merchant_admin? || current_merchant_employee? %>
             <%= link_to 'Merchant Dashboard', '/merchant/dashboard' %>

--- a/spec/features/cart/checkout_spec.rb
+++ b/spec/features/cart/checkout_spec.rb
@@ -3,6 +3,8 @@ require 'rails_helper'
 RSpec.describe 'Cart show' do
   describe 'When I have added items to my cart' do
     before(:each) do
+      @user = User.create(name: 'Christopher', address: '123 Oak Ave', city: 'Denver', state: 'CO', zip: 80021, email: 'christopher@email.com', password: 'p@ssw0rd', role: 0)
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@user)
       @mike = Merchant.create(name: "Mike's Print Shop", address: '123 Paper Rd.', city: 'Denver', state: 'CO', zip: 80203)
       @meg = Merchant.create(name: "Meg's Bike Shop", address: '123 Bike Rd.', city: 'Denver', state: 'CO', zip: 80203)
 

--- a/spec/features/merchants/destroy_spec.rb
+++ b/spec/features/merchants/destroy_spec.rb
@@ -26,6 +26,8 @@ RSpec.describe "As a visitor" do
     end
 
     it "I can't delete a merchant that has orders" do
+      user = User.create(name: 'Christopher', address: '123 Oak Ave', city: 'Denver', state: 'CO', zip: 80021, email: 'christopher@email.com', password: 'p@ssw0rd', role: 0)
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
       mike = Merchant.create(name: "Mike's Print Shop", address: '123 Paper Rd.', city: 'Denver', state: 'CO', zip: 80203)
       meg = Merchant.create(name: "Meg's Bike Shop", address: '123 Bike Rd.', city: 'Denver', state: 'CO', zip: 80203)
       brian = Merchant.create(name: "Brian's Dog Shop", address: '123 Dog Rd.', city: 'Denver', state: 'CO', zip: 80204)

--- a/spec/features/orders/creation_spec.rb
+++ b/spec/features/orders/creation_spec.rb
@@ -9,6 +9,8 @@
 RSpec.describe("Order Creation") do
   describe "When I check out from my cart" do
     before(:each) do
+      @user = User.create(name: 'Christopher', address: '123 Oak Ave', city: 'Denver', state: 'CO', zip: 80021, email: 'christopher@email.com', password: 'p@ssw0rd', role: 0)
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@user)
       @mike = Merchant.create(name: "Mike's Print Shop", address: '123 Paper Rd.', city: 'Denver', state: 'CO', zip: 80203)
       @meg = Merchant.create(name: "Meg's Bike Shop", address: '123 Bike Rd.', city: 'Denver', state: 'CO', zip: 80203)
       @tire = @meg.items.create(name: "Gatorskins", description: "They'll never pop!", price: 100, image: "https://www.rei.com/media/4e1f5b05-27ef-4267-bb9a-14e35935f218?size=784x588", inventory: 12)

--- a/spec/features/orders/new_spec.rb
+++ b/spec/features/orders/new_spec.rb
@@ -1,6 +1,8 @@
 RSpec.describe("New Order Page") do
   describe "When I check out from my cart" do
     before(:each) do
+      @user = User.create(name: 'Christopher', address: '123 Oak Ave', city: 'Denver', state: 'CO', zip: 80021, email: 'christopher@email.com', password: 'p@ssw0rd', role: 0)
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@user)
       @mike = Merchant.create(name: "Mike's Print Shop", address: '123 Paper Rd.', city: 'Denver', state: 'CO', zip: 80203)
       @meg = Merchant.create(name: "Meg's Bike Shop", address: '123 Bike Rd.', city: 'Denver', state: 'CO', zip: 80203)
       @tire = @meg.items.create(name: "Gatorskins", description: "They'll never pop!", price: 100, image: "https://www.rei.com/media/4e1f5b05-27ef-4267-bb9a-14e35935f218?size=784x588", inventory: 12)

--- a/spec/features/users/cart_spec.rb
+++ b/spec/features/users/cart_spec.rb
@@ -1,0 +1,29 @@
+require 'rails_helper'
+
+describe 'User Cart Checkout' do
+  describe "when a user visits their cart with items in their cart'" do
+    before(:each) do
+      @mike = Merchant.create(name: "Mike's Print Shop", address: '123 Paper Rd.', city: 'Denver', state: 'CO', zip: 80203)
+      @paper = @mike.items.create(name: "Lined Paper", description: "Great for writing on!", price: 20, image: "https://cdn.vertex42.com/WordTemplates/images/printable-lined-paper-wide-ruled.png", inventory: 25)
+      @pencil = @mike.items.create(name: "Yellow Pencil", description: "You can write on paper with it!", price: 2, image: "https://images-na.ssl-images-amazon.com/images/I/31BlVr01izL._SX425_.jpg", inventory: 100)
+      @user = User.create(name: 'Christopher', address: '123 Oak Ave', city: 'Denver', state: 'CO', zip: 80021, email: 'christopher@email.com', password: 'p@ssw0rd', role: 0)
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@user)
+    end
+    it 'they will not see a message that says that they have to login or register to checkout their items, and they will see a link to checkout' do
+
+      visit "/items/#{@paper.id}"
+      click_on "Add To Cart"
+
+      visit "/items/#{@pencil.id}"
+      click_on "Add To Cart"
+
+      within 'nav' do
+        expect(page).to have_content("Cart: 2")
+      end
+
+      visit "/cart"
+      expect(page).to_not have_content("You must login or register in order to checkout")
+      expect(page).to have_link("Checkout")
+    end
+  end
+end

--- a/spec/features/users/logout_spec.rb
+++ b/spec/features/users/logout_spec.rb
@@ -34,30 +34,43 @@ describe "When a user logs out" do
 
     mike = Merchant.create(name: "Mike's Print Shop", address: '123 Paper Rd.', city: 'Denver', state: 'CO', zip: 80203)
     paper = mike.items.create(name: "Lined Paper", description: "Great for writing on!", price: 20, image: "https://cdn.vertex42.com/WordTemplates/images/printable-lined-paper-wide-ruled.png", inventory: 3)
+
     visit "/items/#{paper.id}"
+
     click_on "Add To Cart"
+
     visit '/items'
+
     within 'nav' do
       expect(page).to have_content("Cart: 1")
     end
+
     expect(page).to have_content("Logged in as #{name}")
+
     click_link("Logout")
+
     expect(current_path).to eq("/")
     expect(page).to have_content("You have been logged out.")
+
     within 'nav' do
       expect(page).to have_content("Cart: 0")
     end
+
     visit "/cart"
+
     expect(page).to have_content("Cart is currently empty")
     expect(page).to have_link("Login")
     expect(page).to have_link("Register")
     expect(page).to_not have_link("Profile")
     expect(page).to_not have_link("Logout")
     expect(page).to_not have_content("Logged in as #{name}")
+
     within 'nav' do
       expect(page).to have_content("Cart: 0")
     end
+
     visit "/cart"
+
     expect(page).to have_content("Cart is currently empty")
   end
 end

--- a/spec/features/users/profile_spec.rb
+++ b/spec/features/users/profile_spec.rb
@@ -80,7 +80,7 @@ RSpec.describe "User Profile" do
     it 'I must use a unique email address when updating my profile' do
       visit '/profile/edit'
 
-      email = 'christopher@email.com'
+      email = 'ck@email.com'
 
       fill_in "Email", with: email
       click_button 'Update Profile'

--- a/spec/features/users/site_restriction_spec.rb
+++ b/spec/features/users/site_restriction_spec.rb
@@ -23,4 +23,33 @@ describe 'User Site Navigation' do
 
     end
   end
+
+  describe "when user attempts to navigate to '/profile', '/cart', '/items', or '/merchants/'" do
+    it 'they can do so' do
+      regular_user = User.create(  name: "alec",
+                          address: "234 Main",
+                          city: "Denver",
+                          state: "CO",
+                          zip: 80204,
+                          email: "alec@gmail.com",
+                          password: "password",
+                          role: 0)
+      allow_any_instance_of(ApplicationController)
+              .to receive(:current_user)
+              .and_return(regular_user)
+
+      visit "/merchants"
+      expect(current_path).to eq("/merchants")
+
+      visit "/profile"
+      expect(current_path).to eq("/profile")
+
+      visit "/items"
+      expect(current_path).to eq("/items")
+
+      visit "/cart"
+      expect(current_path).to eq("/cart")
+
+    end
+  end
 end

--- a/spec/features/visitor/cart_spec.rb
+++ b/spec/features/visitor/cart_spec.rb
@@ -1,0 +1,27 @@
+require 'rails_helper'
+
+describe 'Visitor Cart Checkout' do
+  describe "when a visitor visits their cart with items in their cart'" do
+    before(:each) do
+      @mike = Merchant.create(name: "Mike's Print Shop", address: '123 Paper Rd.', city: 'Denver', state: 'CO', zip: 80203)
+      @paper = @mike.items.create(name: "Lined Paper", description: "Great for writing on!", price: 20, image: "https://cdn.vertex42.com/WordTemplates/images/printable-lined-paper-wide-ruled.png", inventory: 25)
+      @pencil = @mike.items.create(name: "Yellow Pencil", description: "You can write on paper with it!", price: 2, image: "https://images-na.ssl-images-amazon.com/images/I/31BlVr01izL._SX425_.jpg", inventory: 100)
+    end
+    it 'they will see a message that says that they have to login or register to checkout their items, and they will not see a link to checkout' do
+
+      visit "/items/#{@paper.id}"
+      click_on "Add To Cart"
+
+      visit "/items/#{@pencil.id}"
+      click_on "Add To Cart"
+
+      within 'nav' do
+        expect(page).to have_content("Cart: 2")
+      end
+
+      visit "/cart"
+      expect(page).to have_content("You must login or register in order to checkout")
+      expect(page).to_not have_link("Checkout")
+    end
+  end
+end

--- a/spec/features/visitor/cart_spec.rb
+++ b/spec/features/visitor/cart_spec.rb
@@ -20,8 +20,25 @@ describe 'Visitor Cart Checkout' do
       end
 
       visit "/cart"
-      expect(page).to have_content("You must login or register in order to checkout")
+
       expect(page).to_not have_link("Checkout")
+
+      within '#visitor-checkout-message' do
+        expect(page).to have_content("You must log in or register in order to checkout")
+        expect(page).to have_link("log in")
+        expect(page).to have_link("register")
+        click_link("log in")
+      end
+
+      expect(current_path).to eq('/login')
+
+      visit "/cart"
+
+      within '#visitor-checkout-message' do
+        click_link("register")
+      end
+
+      expect(current_path).to eq('/register')
     end
   end
 end


### PR DESCRIPTION
- Update cart show page so that only registered users can checkout, and visitors will see a message indicating that they must register or login to checkout. The words "register" and "log in" in the message are links to register and log in.

- Update navbar so that users can access their profile by clicking on the profile link

- Update various tests involving checking out so that login process is in setup